### PR TITLE
remove -ipv6 command option

### DIFF
--- a/applications/luci-app-cloudflarespeedtest/root/usr/bin/cloudflarespeedtest/cloudflarespeedtest.sh
+++ b/applications/luci-app-cloudflarespeedtest/root/usr/bin/cloudflarespeedtest/cloudflarespeedtest.sh
@@ -45,7 +45,7 @@ function speed_test(){
 	command="/usr/bin/cdnspeedtest -sl $((speed*125/1000)) -url ${custome_url} -o ${IP_FILE}"
 
 	if [ $ipv6_enabled -eq "1" ] ;then
-		command="${command} -f ${IPV6_TXT} -ipv6"
+		command="${command} -f ${IPV6_TXT}"
 	else
 		command="${command} -f ${IPV4_TXT}"
 	fi


### PR DESCRIPTION
As the upsteam has removed the -ipv6 option, it would be necessary to remove -ipv6 here to enable ipv6 speed test.